### PR TITLE
Fix for values of 0

### DIFF
--- a/csv-to-influxdb.py
+++ b/csv-to-influxdb.py
@@ -100,8 +100,8 @@ def loadCsv(inputfilename, servername, user, password, dbname, metric,
                         v = str2bool(row[f])
                     else:
                         v = row[f]
-                if v:
-                    fields[f] = v
+                
+                fields[f] = v
 
 
             point = {"measurement": metric, "time": timestamp, "fields": fields, "tags": tags}


### PR DESCRIPTION
If the data that you are trying to import is exactly 0, then the if statement will evaluate to false and not assign a value to `fields[f]`. This will then cause the subsequent writes to fail. 

Given that v is initialised to 0 anyway, the issue can be fixed by simply removing the if statement. 
The alternative is to do 
```
if v is not None:
       fields[f] = v
```