### PR TITLE
Add force flag as parameter

### DIFF
--- a/csv-to-influxdb.py
+++ b/csv-to-influxdb.py
@@ -106,7 +106,6 @@ def loadCsv(inputfilename, servername, user, password, dbname, metric,
 
 
             point = {"measurement": metric, "time": timestamp, "fields": fields, "tags": tags}
-            print(force)
 
             datapoints.append(point)
             count+=1


### PR DESCRIPTION
Hiya! :heart: this repo!

See some suggested modifications below which I hope will be useful. 

If a given batch has issues, then `client.write_points` will raise an exception. The following modifications do the following:

* Catch the exception and handle it appropriately
* Have the possibility of raising a force flag that can ignore problematic batches and continue with the write process.